### PR TITLE
fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@ int main(void){
   Area gameArea = {45, 85, 45, 85};
   gameState = mainMenuState;
   int pigToken = 0;
+  int aktualny_poziom = 0;
  
   // static Timer nieuzyte(10000);         // nieużyty timer nieużyte >.<
   static Timer frozenTimer(5000);
@@ -179,17 +180,12 @@ Texture2D bulletTimeSprite[2] = {LoadTexture("assets/sprites/powerups/redpill2.p
                   }
               }
 
-              for (size_t i = 0; i < monkeyList.size(); i++)
-                  for (size_t j = 0; j < pigList.size(); j++) {
-                          if (monkeyList[i].dead) {
-                              monkeyList.erase(monkeyList.begin() + i); // Remove dead monkeys
-                          }
-
                           // WARUNEK ZMIANY TRUDNOŚCI - CO 100PKT
-                          int aktualny_poziom = 0;
+        
                           if (points > 99 + aktualny_poziom && points < 99 + aktualny_poziom + 12) {
                               aktualny_poziom += 100;
-                              wkurwiacz += 0.0015;
+                              wkurwiacz += 0.25;
+                            // std::cout << "ZWIEKSZONO POZIOM - " << aktualny_poziom << " " << wkurwiacz << std::endl;
                           }
 
                           if (points < 99) {
@@ -197,9 +193,23 @@ Texture2D bulletTimeSprite[2] = {LoadTexture("assets/sprites/powerups/redpill2.p
                               wkurwiacz = 1.5;
                           }
 
-                          monkeyList[i].maxspeed = wkurwiacz;
-                          pigList[j].maxspeed = wkurwiacz - 0.5;
+              for (size_t i = 0; i < monkeyList.size(); i++)
+                  for (size_t j = 0; j < pigList.size(); j++) {
+                          if (monkeyList[i].dead) {
+                              monkeyList.erase(monkeyList.begin() + i); // Remove dead monkeys
+                          }
 
+
+                        if(monkeyList[i].frozen==0)
+                        {
+                          monkeyList[i].maxspeed = wkurwiacz;
+                        //   std::cout << monkeyList[i].maxspeed;
+                        }
+
+                        if(pigList[j].frozen==0)
+                        {
+                          pigList[j].maxspeed = wkurwiacz - 0.5;
+                        }
                           if (snake.collide(monkeyList[i].monkeyRec) || snake.collide(pigList[j].pigRec)) {
                               gameState = deathScreenState;
                               PlaySound(GameOver);
@@ -315,7 +325,6 @@ Texture2D bulletTimeSprite[2] = {LoadTexture("assets/sprites/powerups/redpill2.p
                           monkeyList.clear();
                           pigList.clear();
                           snake = Snake(snakeSprite, 15);
-                          SetTargetFPS(60);
                           fruit.moveFruit();
                           bullet.moveBulletTime();
                           nuke.moveNuke();

--- a/src/monkey.cpp
+++ b/src/monkey.cpp
@@ -34,7 +34,7 @@ void Malpa::update()
     // Reset accelertion to 0 each cycle
     acceleration = Vector2Scale(acceleration,0);
     draw();
-    maxspeed += 0.001;
+    // maxspeed += 0.001;
     if (separationRange > 60)
     {
       separationRange -= 0.1;

--- a/src/pig.cpp
+++ b/src/pig.cpp
@@ -30,7 +30,7 @@ void Pig::update() {
     // Reset accelertion to 0 each cycle
     acceleration = Vector2Scale(acceleration, 0);
     draw();
-    maxspeed += 0.001;
+    // maxspeed += 0.001;
 }
 bool Pig::collide(Rectangle rec) {
     if (CheckCollisionRecs(pigRec, rec)) {


### PR DESCRIPTION
- naprawiony bug gdzie jesli bylismy blisko zmiany poziomu na trudniejszy a przeciwnik był akurat zamrożony to został odmrażany gdy wbiliśmy kolejny poziom
- zmieniona wartość przyśpieszenia dodawanego co 100 pkt + wyrzucenie tego z pętli (do dalszych testów)
- usunięte zwiekszanie maxspeeda z klasy monkey i pig, możliwe że powodowały nakładające się wartości co zwiększało prędkości przeciwników